### PR TITLE
تحسين: إضافة معالجة قوية للأخطاء عند تحليل رسائل JSON

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -34,7 +34,7 @@ void LSPServer::initialize(const json& params) {
 			{"result", {
 				{"capabilities", capabilities}
 			}},
-		});
+	});
 }
 
 void LSPServer::handleCompletion(const json& params, const json& id) {
@@ -87,8 +87,26 @@ void LSPServer::run() {
 		// Read JSON body
 		std::vector<char> buffer(length);
 		std::cin.read(buffer.data(), length);
-		json msg = json::parse(buffer.begin(), buffer.end());
 
-		handleMessage(msg);
+		// تأكد من قراءة كل البيانات
+		if (!std::cin)
+		{
+			std::cerr << "[Alif-LSP] Error reading input" << std::endl;
+			return;
+		}
+		// هنا نقوم بتحليل الرسالة الواردة
+		// Parse the JSON message
+		try
+		{
+			json msg = json::parse(buffer.begin(), buffer.end());
+			// ممكن نعمل لوج للرسالة المستلمة لأغراض التصحيح
+			// std::cerr << "[Alif-LSP] Received: " << msg.dump(2) << std::endl;
+			handleMessage(msg);
+		}
+		catch (const std::exception &e)
+		{
+
+			std::cerr << "[Alif-LSP] JSON Parse Error: " << e.what() << std::endl;
+		}
 	}
 }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -34,7 +34,7 @@ void LSPServer::initialize(const json& params) {
 			{"result", {
 				{"capabilities", capabilities}
 			}},
-	});
+		});
 }
 
 void LSPServer::handleCompletion(const json& params, const json& id) {
@@ -89,22 +89,18 @@ void LSPServer::run() {
 		std::cin.read(buffer.data(), length);
 
 		// تأكد من قراءة كل البيانات
-		if (!std::cin)
-		{
+		if (!std::cin) {
 			std::cerr << "[Alif-LSP] Error reading input" << std::endl;
 			return;
 		}
 		// هنا نقوم بتحليل الرسالة الواردة
-		// Parse the JSON message
-		try
-		{
+		try {
 			json msg = json::parse(buffer.begin(), buffer.end());
-			// ممكن نعمل لوج للرسالة المستلمة لأغراض التصحيح
+			// ممكن نعمل log للرسالة المستلمة لأغراض التصحيح
 			// std::cerr << "[Alif-LSP] Received: " << msg.dump(2) << std::endl;
 			handleMessage(msg);
 		}
-		catch (const std::exception &e)
-		{
+		catch (const std::exception& e) {
 
 			std::cerr << "[Alif-LSP] JSON Parse Error: " << e.what() << std::endl;
 		}


### PR DESCRIPTION
### نظرة عامة

هذا التغيير يعزز استقرار خادم اللغة عن طريق إضافة معالجة للأخطاء (Error Handling) حول عملية تحليل رسائل JSON الواردة.

في السابق، إذا استقبل الخادم رسالة JSON غير مكتملة أو تالفة من المحرر، كان استدعاء `json::parse()` يتسبب في حدوث exception غير معالج، مما يؤدي إلى انهيار الخادم بالكامل. هذا يجعل الخادم غير مستقر وعرضة للتوقف عن العمل بسبب أخطاء في الاتصال.

تم الآن وضع الكود المسؤول عن تحليل JSON داخل كتلة `try...catch`. في حالة فشل التحليل، سيتم:
1.  التقاط الـ `exception`.
2.  تسجيل رسالة خطأ واضحة في `stderr` تشرح المشكلة.
3.  متابعة عمل الخادم وانتظار الرسالة التالية بدلاً من الانهيار.
-   **زيادة الاستقرار:** الخادم لن ينهار بعد الآن بسبب بيانات إدخال خاطئة.
-   **تحسين تصحيح الأخطاء (Debugging):** رسائل الخطأ الجديدة ستساعد في تشخيص مشاكل الاتصال مع المحرر بسهولة أكبر.