### PR TITLE
تصحيح: استخدام معرّف الطلب الصحيح في استجابة التهيئة (initialize)

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -21,7 +21,7 @@ void LSPServer::sendResponse(const json& response) {
 	std::cout.flush();
 }
 
-void LSPServer::initialize(const json& params) {
+void LSPServer::initialize(const json& params, const json& id) {
 	json capabilities = {
 		{"completionProvider", {
 			{"triggerCharacters", true}
@@ -30,7 +30,7 @@ void LSPServer::initialize(const json& params) {
 	};
 
 	sendResponse({
-		{"id", 1},
+		{"id", id},
 			{"result", {
 				{"capabilities", capabilities}
 			}},
@@ -50,7 +50,7 @@ void LSPServer::handleCompletion(const json& params, const json& id) {
 
 void LSPServer::handleMessage(const json& msg) {
 	if (msg.contains("id") && msg["method"] == "initialize") {
-		initialize(msg["params"]);
+		initialize(msg["params"], msg["id"]);
 	}
 	else if (msg["method"] == "textDocument/didOpen") {
 		auto doc = msg["params"]["textDocument"];

--- a/src/include/Server.h
+++ b/src/include/Server.h
@@ -11,6 +11,6 @@ public:
 
 private:
 	void sendResponse(const json& response);
-	void initialize(const json& params);
+	void initialize(const json& params, const json& id);
 	void handleCompletion(const json& params, const json& id);
 };


### PR DESCRIPTION
### نظرة عامة

يُصلح هذا الطلب خطأً في معالجة طلب التهيئة `initialize` لضمان التوافق الكامل مع مواصفات بروتوكول خادم اللغة (LSP).

سابقاً، كان الخادم يرد على طلب التهيئة بمعرّف (`id`) ثابت وقيمته `1`، بغض النظر عن المعرّف الذي تم إرساله في الطلب الأصلي من محرر الكود. هذا السلوك يخالف مواصفات بروتوكول LSP، الذي ينص بوضوح على أن معرّف الاستجابة يجب أن يطابق تمامًا معرّف الطلب. قد يتسبب هذا في تجاهل المحرر لاستجابة الخادم.

تم تعديل دالة `initialize` لتستقبل معرّف الطلب (`id`) كمعامل (parameter). عند استدعاء الدالة من `handleMessage`، يتم تمرير المعرّف الفعلي للطلب، والذي يُستخدم بعد ذلك عند بناء وإرسال الاستجابة.